### PR TITLE
CloudFront Distribution ID or multiple IDs

### DIFF
--- a/invalidate-cloudfront/action.yml
+++ b/invalidate-cloudfront/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         if ! command -v aws &> /dev/null; then
           echo "Installing AWS CLI..."
-          curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
           sudo ./aws/install
         else

--- a/invalidate-cloudfront/action.yml
+++ b/invalidate-cloudfront/action.yml
@@ -28,8 +28,8 @@ runs:
     - name: Invalidate CloudFront Distributions
       shell: bash
       run: |
-        distributions=$(echo "${{ inputs.distribution }}" | tr ',' ' ')
-        echo "📦 Distributions to invalidate (in parallel):"
+        distributions=$(echo "${{ inputs.distribution }}" | tr ',\n' ' ' | tr -s ' ')
+        echo "Distributions to invalidate (in parallel):"
         echo "$distributions"
 
         failed=()

--- a/invalidate-cloudfront/action.yml
+++ b/invalidate-cloudfront/action.yml
@@ -3,7 +3,7 @@ description: "Invalidate one or multiple CloudFront distributions with retries"
 
 inputs:
   distribution:
-    description: "CloudFront Distribution ID or multiple IDs separated by comma/space"
+    description: "CloudFront Distribution ID or multiple IDs separated by comma/space/newline"
     required: true
   retrying:
     description: "Retry count per distribution"
@@ -29,36 +29,44 @@ runs:
       shell: bash
       run: |
         distributions=$(echo "${{ inputs.distribution }}" | tr ',' ' ')
-        echo "Distributions to invalidate: $distributions"
+        echo "📦 Distributions to invalidate (in parallel):"
+        echo "$distributions"
 
-        any_failed=false
+        failed=()
 
-        for dist_id in $distributions; do
-          echo "Starting invalidation for distribution: $dist_id"
-          success=false
-
+        invalidate_distribution() {
+          local dist_id=$1
+          echo "Starting invalidation for $dist_id"
           for i in $(seq 1 ${{ inputs.retrying }}); do
             echo "Attempt #$i for $dist_id"
             if aws cloudfront create-invalidation \
               --distribution-id "$dist_id" \
-              --paths "/*"; then
+              --paths "/*" \
+              --caller-reference "$(date +%s)-$dist_id-$i"; then
               echo "Invalidation succeeded for $dist_id"
-              success=true
-              break
+              return 0
             else
               echo "Failed attempt #$i for $dist_id, retrying in $((i * 10)) seconds..."
               sleep $((i * 10))
             fi
           done
+          echo "All attempts failed for $dist_id"
+          failed+=("$dist_id")
+          return 1
+        }
 
-          if [ "$success" = false ]; then
-            echo "All attempts failed for $dist_id"
-            any_failed=true
-          fi
+        export -f invalidate_distribution
+        export failed
+
+        for dist_id in $distributions; do
+          invalidate_distribution "$dist_id" &
         done
 
-        if [ "$any_failed" = true ]; then
-          echo "Some invalidations failed. Exiting with error."
+        wait
+
+        if [ "${#failed[@]}" -gt 0 ]; then
+          echo "Some invalidations failed:"
+          printf ' - %s\n' "${failed[@]}"
           exit 1
         fi
 

--- a/invalidate-cloudfront/action.yml
+++ b/invalidate-cloudfront/action.yml
@@ -1,45 +1,65 @@
 name: "Invalidate CloudFront"
-description: "Invalidate CloudFront with retries"
+description: "Invalidate one or multiple CloudFront distributions with retries"
 
 inputs:
   distribution:
-    description: "CloudFront Distribution ID"
+    description: "CloudFront Distribution ID or multiple IDs separated by comma/space"
     required: true
   retrying:
-    description: "Retrying count"
+    description: "Retry count per distribution"
     required: false
     default: 1
 
 runs:
   using: "composite"
-
   steps:
     - name: Install AWS CLI
       shell: bash
       run: |
         if ! command -v aws &> /dev/null; then
           echo "Installing AWS CLI..."
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
           sudo ./aws/install
         else
           echo "AWS CLI already installed"
         fi
 
-    - name: Invalidate CloudFront with retries
+    - name: Invalidate CloudFront Distributions
       shell: bash
       run: |
-        for i in $(seq 1 ${{ inputs.retrying }}); do
-          echo "Attempt #$i"
-          if aws cloudfront create-invalidation \
-            --distribution-id ${{ inputs.distribution }} \
-            --paths "/*"; then
-            echo "Invalidation succeeded"
-            exit 0
-          else
-            echo "Failed, retrying in $((i * 10)) seconds..."
-            sleep $((i * 10))
+        distributions=$(echo "${{ inputs.distribution }}" | tr ',' ' ')
+        echo "Distributions to invalidate: $distributions"
+
+        any_failed=false
+
+        for dist_id in $distributions; do
+          echo "Starting invalidation for distribution: $dist_id"
+          success=false
+
+          for i in $(seq 1 ${{ inputs.retrying }}); do
+            echo "Attempt #$i for $dist_id"
+            if aws cloudfront create-invalidation \
+              --distribution-id "$dist_id" \
+              --paths "/*"; then
+              echo "Invalidation succeeded for $dist_id"
+              success=true
+              break
+            else
+              echo "Failed attempt #$i for $dist_id, retrying in $((i * 10)) seconds..."
+              sleep $((i * 10))
+            fi
+          done
+
+          if [ "$success" = false ]; then
+            echo "All attempts failed for $dist_id"
+            any_failed=true
           fi
         done
-        echo "All attempts failed. Exiting with error."
-        exit 1
+
+        if [ "$any_failed" = true ]; then
+          echo "Some invalidations failed. Exiting with error."
+          exit 1
+        fi
+
+        echo "All invalidations completed successfully!"

--- a/invalidate-cloudfront/readme.md
+++ b/invalidate-cloudfront/readme.md
@@ -17,7 +17,7 @@
 ### For one
 ```
 - name: Invalidate CloudFront
-  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@main
+  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@v8.0.0
   with:
     distribution: E2M8ILOBF84EDF
     retrying: 3

--- a/invalidate-cloudfront/readme.md
+++ b/invalidate-cloudfront/readme.md
@@ -4,10 +4,10 @@
 
 ```
   distribution:
-    description: "CloudFront Distribution ID"
+    description: "CloudFront Distribution ID or multiple IDs separated by comma/space/newline"
     required: true
   retrying:
-    description: "Retrying count"
+    description: "Retry count per distribution"
     required: false
     default: 1
 ```

--- a/invalidate-cloudfront/readme.md
+++ b/invalidate-cloudfront/readme.md
@@ -14,10 +14,39 @@
 
 ## Example Usage
 
+### For one
 ```
 - name: Invalidate CloudFront
   uses: your-org/your-repo/.github/actions/invalidate-cloudfront@main
   with:
-    distribution-id: E2M8ILOBF84EDF
+    distribution: E2M8ILOBF84EDF
+    retrying: 3
+```
+
+### For many
+```
+- name: Invalidate CloudFront
+  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@v8.0.0
+  with:
+    distribution: "EPIJXYZ88VKBF E1ABCDEF999999 E3EXAMPLE888888"
+    retrying: 3
+```
+OR
+```
+- name: Invalidate CloudFront
+  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@v8.0.0
+  with:
+    distribution: "EPIJXYZ88VKBF,E1ABCDEF999999,E3EXAMPLE888888"
+    retrying: 3
+```
+OR
+```
+- name: Invalidate multiple CloudFront
+  uses: amomama/amo-actions/invalidate-cloudfront@v8.0.0
+  with:
+    distribution: |
+        EPIJXYZ88VKBF
+        E1ABCDEF999999
+        E3EXAMPLE888888
     retrying: 3
 ```


### PR DESCRIPTION
https://github.com/amomama/amo-fe/pull/1561/files
Тут є зачаток джоби яка задеплоїть всю рсок/фінтріт апку
очевидно повинен бути крок інвалідації кф всіх сайтів
розширив існуючий крок
не уводив distributions, залишив distribution
потрібно тестувати)

- [ ] змержити
- [ ] створити тег

### For many
```
- name: Invalidate CloudFront
  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@v8.0.0
  with:
    distribution: "EPIJXYZ88VKBF E1ABCDEF999999 E3EXAMPLE888888"
    retrying: 3
```
OR
```
- name: Invalidate CloudFront
  uses: your-org/your-repo/.github/actions/invalidate-cloudfront@v8.0.0
  with:
    distribution: "EPIJXYZ88VKBF,E1ABCDEF999999,E3EXAMPLE888888"
    retrying: 3
```
OR
```
- name: Invalidate multiple CloudFront
  uses: amomama/amo-actions/invalidate-cloudfront@v8.0.0
  with:
    distribution: |
        EPIJXYZ88VKBF
        E1ABCDEF999999
        E3EXAMPLE888888
    retrying: 3
```